### PR TITLE
The default value of fontset  should be empty.

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,5 +1,5 @@
 % !Mode:: "TeX:UTF-8"
-\documentclass[capcenterlast=true,subcapcenterlast=true,openright=true,absupper=true,fontset=windowsnew,type=doctor]{hithesis}
+\documentclass[capcenterlast=true,subcapcenterlast=true,openright=true,absupper=true,fontset=,type=doctor]{hithesis}
 % 此处选项中不要有空格
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % 必填选项


### PR DESCRIPTION
在MacTex环境，如果fontset值非空，编译会一直失败。需要改成如注释所说的“缺省值为空，自动识别系统并匹配字体”，才能正常编译。