### PR TITLE
fix the \Bbbk duplicate definition bug by loading ams* packages first

### DIFF
--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -1149,6 +1149,11 @@
 %    \begin{macrocode}
 \RequirePackage{amsmath}
 %    \end{macrocode}
+% 定理类环境宏包，其中 \pkg{amsmath} 选项用来兼容 \AmSTeX\ 的宏包
+%    \begin{macrocode}
+\RequirePackage[amsmath,thmmarks,hyperref]{ntheorem}
+\RequirePackage{amssymb}
+%    \end{macrocode}
 % \pkg{newtx} 设置 Times New Roman，Helvetica。
 %    \begin{macrocode}
 \RequirePackage[defaultsups]{newtxtext}
@@ -1200,10 +1205,7 @@
 %    \begin{macrocode}
 \RequirePackage{CJKfntef}
 %    \end{macrocode}
-% 定理类环境宏包，其中 \pkg{amsmath} 选项用来兼容 \AmSTeX\ 的宏包
-%    \begin{macrocode}
-\RequirePackage[amsmath,thmmarks,hyperref]{ntheorem}
-%    \end{macrocode}
+
 % 表格控制
 %    \begin{macrocode}
 \RequirePackage{longtable}
@@ -1308,7 +1310,6 @@
 %    \begin{macrocode}
 \RequirePackage{changepage}
 \RequirePackage{multicol}
-\RequirePackage{amssymb}
 \RequirePackage[below]{placeins}%允许上一个section的浮动图形出现在下一个section的开始部分,还提供\FloatBarrier命令,使所有未处理的浮动图形立即被处理
 \RequirePackage{flafter}       % 使得所有浮动体不能被放置在其浮动环境之前，以免浮动体在引述它的文本之前出现.
 \RequirePackage{multirow}       %使用Multirow宏包，使得表格可以合并多个row格


### PR DESCRIPTION
环境：Windows及Linux环境下，TeX Live使用tlmgr将所有包更新到最新（20200130）
问题：(c:/texlive/2019/texmf-dist/tex/latex/amsfonts/amsfonts.sty)
             ! LaTeX Error: Command `\Bbbk' already defined.
解决：将ams*相关的包提前加载