### PR TITLE
修改 theoremsymbols 的位置使 proof 环境带 \qed

### DIFF
--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -4709,7 +4709,6 @@ delim_1 "\\hspace*{\\fill}"
 % 英文版黑体加粗
 % \changes{v3.0.0}{2020/05/21}{英文版黑体加粗}
 %    \begin{macrocode}
-\theoremsymbol{\ensuremath{\square}}
 \theoremstyle{plain}
 \theoremsymbol{}
 %    \end{macrocode}
@@ -4731,6 +4730,7 @@ delim_1 "\\hspace*{\\fill}"
 \newtheorem{problem}{Problem}[chapter]
 \newtheorem{conjecture}{Conjecture}[chapter]
 \newtheorem{fact}{Fact}[chapter]
+\theoremsymbol{\ensuremath{\square}}
 \newtheorem*{proof}{Proof}
 \else
 \newtheorem{assumption}{假设}[chapter]
@@ -4746,6 +4746,7 @@ delim_1 "\\hspace*{\\fill}"
 \newtheorem{problem}{问题}[chapter]
 \newtheorem{conjecture}{猜想}[chapter]
 \newtheorem{fact}{事实}[chapter]
+\theoremsymbol{\ensuremath{\square}}
 \newtheorem*{proof}{证明}
 \fi
 %</bookcfg>


### PR DESCRIPTION
修改 `\theoremsymbol{\ensuremath{\square}}` 的位置使得中英文的 `proof` 环境自带 `\qed`