### PR TITLE
修改 dtx 使 proof 环境带 \qed

### DIFF
--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -4700,16 +4700,18 @@ delim_1 "\\hspace*{\\fill}"
 %    \begin{macrocode}
 %<*bookcfg>
 \theorembodyfont{\normalfont}
+\theoremsymbol{\ensuremath{\square}}
 \ifhit@english
 \theoremheaderfont{\normalfont\bf}
+\newtheorem*{proof}{Proof}
 \else
 \theoremheaderfont{\normalfont\heiti}
+\newtheorem*{proof}{证明}
 \fi
 %    \end{macrocode}
 % 英文版黑体加粗
 % \changes{v3.0.0}{2020/05/21}{英文版黑体加粗}
 %    \begin{macrocode}
-\theoremsymbol{\ensuremath{\square}}
 \theoremstyle{plain}
 \theoremsymbol{}
 %    \end{macrocode}
@@ -4731,7 +4733,6 @@ delim_1 "\\hspace*{\\fill}"
 \newtheorem{problem}{Problem}[chapter]
 \newtheorem{conjecture}{Conjecture}[chapter]
 \newtheorem{fact}{Fact}[chapter]
-\newtheorem*{proof}{Proof}
 \else
 \newtheorem{assumption}{假设}[chapter]
 \newtheorem{definition}{定义}[chapter]
@@ -4746,7 +4747,6 @@ delim_1 "\\hspace*{\\fill}"
 \newtheorem{problem}{问题}[chapter]
 \newtheorem{conjecture}{猜想}[chapter]
 \newtheorem{fact}{事实}[chapter]
-\newtheorem*{proof}{证明}
 \fi
 %</bookcfg>
 %<*artcfg>


### PR DESCRIPTION
修改 `hithesis.dtx` 使 proof 环境带 \qed, 且新定义的环境不带 `\qed