### PR TITLE
win下latexmk编译找不到thesis.tex;cp文件

### DIFF
--- a/examples/hitart/reportplus/latexmkrc
+++ b/examples/hitart/reportplus/latexmkrc
@@ -6,5 +6,5 @@ $bibtex_use = 2;
 $recorder = 1;
 $preview_continuous_mode = 1;
 $clean_ext = "synctex.gz acn acr alg aux bbl bcf blg brf fdb_latexmk glg glo gls idx ilg ind lof log lot out run.xml toc pdf thm toe ist idx";
-$pdflatex = "xelatex -file-line-error --shell-escape -src-specials -synctex=1 -interaction=nonstopmode %O %S;cp %D %R.pdf";
+$pdflatex = "xelatex -file-line-error --shell-escape -src-specials -synctex=1 -interaction=nonstopmode %O %S cp %D %R.pdf";
 $pdf_update_method = 0;

--- a/examples/hitart/reports/latexmkrc
+++ b/examples/hitart/reports/latexmkrc
@@ -6,5 +6,5 @@ $bibtex_use = 2;
 $recorder = 1;
 $preview_continuous_mode = 1;
 $clean_ext = "synctex.gz acn acr alg aux bbl bcf blg brf fdb_latexmk glg glo gls idx ilg ind lof log lot out run.xml toc pdf thm toe ist idx";
-$pdflatex = "xelatex -file-line-error --shell-escape -src-specials -synctex=1 -interaction=nonstopmode %O %S;cp %D %R.pdf";
+$pdflatex = "xelatex -file-line-error --shell-escape -src-specials -synctex=1 -interaction=nonstopmode %O %S cp %D %R.pdf";
 $pdf_update_method = 0;

--- a/examples/hitbook/chinese/latexmkrc
+++ b/examples/hitbook/chinese/latexmkrc
@@ -6,7 +6,7 @@ $bibtex_use = 2;
 $recorder = 1;
 $preview_continuous_mode = 1;
 $clean_ext = "synctex.gz acn acr alg aux bbl bcf blg brf fdb_latexmk glg glo gls idx ilg ind lof log lot out run.xml toc pdf thm toe ist idx";
-$pdflatex = "xelatex -file-line-error --shell-escape -src-specials -synctex=1 -interaction=nonstopmode %O %S;cp %D %R.pdf";
+$pdflatex = "xelatex -file-line-error --shell-escape -src-specials -synctex=1 -interaction=nonstopmode %O %S cp %D %R.pdf";
 $pdf_update_method = 0;
 $makeindex = 'internal splitindex';
 sub splitindex {

--- a/examples/hitbook/english/latexmkrc
+++ b/examples/hitbook/english/latexmkrc
@@ -6,5 +6,5 @@ $bibtex_use = 2;
 $recorder = 1;
 $preview_continuous_mode = 1;
 $clean_ext = "synctex.gz acn acr alg aux bbl bcf blg brf fdb_latexmk glg glo gls idx ilg ind lof log lot out run.xml toc pdf thm toe ist idx";
-$pdflatex = "xelatex -file-line-error --shell-escape -src-specials -synctex=1 -interaction=nonstopmode %O %S;cp %D %R.pdf";
+$pdflatex = "xelatex -file-line-error --shell-escape -src-specials -synctex=1 -interaction=nonstopmode %O %S cp %D %R.pdf";
 $pdf_update_method = 0;


### PR DESCRIPTION
windows下使用示例latexmkrc会提示找不到thesis
! I can't find file `thesis.tex;cp'.
<*> thesis.tex;cp
环境信息
XeTeX 3.141592653-2.6-0.999993 (TeX Live 2021/W32TeX)
Latexmk: This is Latexmk, John Collins, 29 September 2020, version: 4.70b.