### PR TITLE
保证之前的浮动体不会在授权页之后输出

### DIFF
--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -6673,6 +6673,7 @@ delim_1 "\\hspace*{\\fill}"
   \IfNoValueTF{#1}{%
     \ifhit@bachelor\hit@authorization@bachelor\else\hit@authorization@other\fi
     }{%
+    \ifhit@openright\cleardoublepage\else\clearpage\fi%
     \includepdf[fitpaper=true,pagecommand={%
 	\thispagestyle{hit@empty}%
 	\phantomsection\addcontentsline{toc}{chapter}{\ifhit@bachelor\hit@declarename@bachelor\else\hit@authorization@ctitle\fi}%


### PR DESCRIPTION
this will fix #102 