### PR TITLE
删除 newtxtext, 改为 TG 系列字体

### DIFF
--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -16,7 +16,7 @@
 %
 % \iffalse
 %<*driver>
-\ProvidesFile{hithesis.dtx}[2022/05/02 3.0.18 Harbin Institute of Technology Thesis Template]
+\ProvidesFile{hithesis.dtx}[2022/05/05 3.0.19 Harbin Institute of Technology Thesis Template]
 \documentclass{ltxdoc}
 \usepackage{dtx-style}
 
@@ -2996,17 +2996,18 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage{amssymb}
 
 %    \end{macrocode}
-% 删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.
-% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.}
+% 删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG TermesX 与 TG Heros.
+% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG Termes 与 TG Heros.}
+% \changes{v3.0.19}{2022/05/05}{将 TG Termes 字体替换为 TG TermesX 字体，与 \pkg{newtxmath} 宏包更适配，删除 \option{Scale} 选项。}
 %    \begin{macrocode}
 
-\setmainfont{texgyretermes}[
-  UprightFont = *-regular ,
-  BoldFont = *-bold ,
-  ItalicFont = *-italic ,
-  BoldItalicFont = *-bolditalic ,
+\setmainfont{TeXGyreTermesX}[
+  UprightFont = *-Regular ,
+  BoldFont = *-Bold ,
+  ItalicFont = *-Italic ,
+  BoldItalicFont = *-BoldItalic ,
   Extension = .otf ,
-  Scale = 1.0]
+  ]
   
 \setsansfont{texgyreheros}[
   UprightFont = *-regular ,
@@ -3014,9 +3015,19 @@ EXECUTE {end.bib}                                 %   end_bib();
   ItalicFont = *-italic ,
   BoldItalicFont = *-bolditalic ,
   Extension = .otf ,
-  Scale = 0.9]
+  ]
+%    \end{macrocode}
+% 删除 \pkg{courier}，将 mono 字体替换为 TG Cursor，至此将正文字体全面替换为 OpenType.
+% \changes{v3.0.19}{2022/05/05}{删除 \pkg{courier}，将 mono 字体替换为 TG Cursor，至此将正文字体全面替换为 OpenType.}
+%    \begin{macrocode}
 
-\RequirePackage{courier}
+\setmonofont{texgyrecursor}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+]
 \RequirePackage{graphicx}
 \RequirePackage{pdfpages}
 \includepdfset{fitpaper=true}
@@ -3427,17 +3438,18 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage{amssymb}
 
 %    \end{macrocode}
-% 删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.
-% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.}
+% 删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG TermesX 与 TG Heros.
+% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG Termes 与 TG Heros.}
+% \changes{v3.0.19}{2022/05/05}{将 TG Termes 字体替换为 TG TermesX 字体，与 \pkg{newtxmath} 宏包更适配，删除 \option{Scale} 选项。}
 %    \begin{macrocode}
 
-\setmainfont{texgyretermes}[
-  UprightFont = *-regular ,
-  BoldFont = *-bold ,
-  ItalicFont = *-italic ,
-  BoldItalicFont = *-bolditalic ,
+\setmainfont{TeXGyreTermesX}[
+  UprightFont = *-Regular ,
+  BoldFont = *-Bold ,
+  ItalicFont = *-Italic ,
+  BoldItalicFont = *-BoldItalic ,
   Extension = .otf ,
-  Scale = 1.0]
+  ]
   
 \setsansfont{texgyreheros}[
   UprightFont = *-regular ,
@@ -3445,12 +3457,47 @@ EXECUTE {end.bib}                                 %   end_bib();
   ItalicFont = *-italic ,
   BoldItalicFont = *-bolditalic ,
   Extension = .otf ,
-  Scale = 0.9]
+  ]
+
+\setmonofont{texgyrecursor}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+]
+%    \end{macrocode}
+% 删除 \pkg{courier}，将 mono 字体替换为 TG Cursor，至此将正文字体全面替换为 OpenType.
+% \changes{v3.0.19}{2022/05/05}{删除 \pkg{courier}，将 mono 字体替换为 TG Cursor，至此将正文字体全面替换为 OpenType.}
+%    \begin{macrocode}
+
+\setmonofont{texgyrecursor}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+]
 
 \ifhit@newtxmath
+%    \end{macrocode}
+% 单独使用 \pkg{newtxmath} 宏包改变数学字体时，会使 \texttt{operators}，\cs{mathrm}，\cs{mathit}，\cs{mathbf} 命令使用 CM 字体，根据 \href{https://github.com/sjtug/SJTUThesis/blob/b164d0f5b3087ed86c1038b5a85014b47a92c6f2/texmf/tex/latex/sjtuthesis/fd/sjtu-math-font-termes.def#L52-L65}{SJTUThesis 的字体设置} 进行调整
+% \changes{v3.0.19}{2022/05/05}{对 \pkg{newtxmath} 宏包打补丁，修复 \texttt{operators}，\cs{mathrm}，\cs{mathit}，\cs{mathbf} 命令的字体问题。}
+%    \begin{macrocode}
+\let\oldencodingdefault\encodingdefault
+\let\oldrmdefault\rmdefault
+\let\oldsfdefault\sfdefault
+\let\oldttdefault\ttdefault
+\usepackage[T1]{fontenc}
+\renewcommand{\rmdefault}{ntxtlf}
+\renewcommand{\sfdefault}{qhv}
+\renewcommand{\ttdefault}{ntxtt}
 \RequirePackage{newtxmath}
+\let\encodingdefault\oldencodingdefault
+\let\rmdefault\oldrmdefault
+\let\sfdefault\oldsfdefault
+\let\ttdefault\oldttdefault
 \fi
-\RequirePackage{courier}
 \RequirePackage{graphicx}
 \RequirePackage{pdfpages}
 \includepdfset{fitpaper=true}
@@ -4111,17 +4158,18 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage[amsmath,thmmarks,hyperref]{ntheorem}
 \RequirePackage{amssymb}
 %    \end{macrocode}
-% 删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.
-% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.}
+% 删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG TermesX 与 TG Heros.
+% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}，由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突，且无法解决，将正文字体替换为 TG Termes 与 TG Heros.}
+% \changes{v3.0.19}{2022/05/05}{将 TG Termes 字体替换为 TG TermesX 字体，与 \pkg{newtxmath} 宏包更适配，删除 \option{Scale} 选项。}
 %    \begin{macrocode}
 
-\setmainfont{texgyretermes}[
-  UprightFont = *-regular ,
-  BoldFont = *-bold ,
-  ItalicFont = *-italic ,
-  BoldItalicFont = *-bolditalic ,
+\setmainfont{TeXGyreTermesX}[
+  UprightFont = *-Regular ,
+  BoldFont = *-Bold ,
+  ItalicFont = *-Italic ,
+  BoldItalicFont = *-BoldItalic ,
   Extension = .otf ,
-  Scale = 1.0]
+  ]
   
 \setsansfont{texgyreheros}[
   UprightFont = *-regular ,
@@ -4129,20 +4177,42 @@ EXECUTE {end.bib}                                 %   end_bib();
   ItalicFont = *-italic ,
   BoldItalicFont = *-bolditalic ,
   Extension = .otf ,
-  Scale = 0.9]
+  ]
+%    \end{macrocode}
+% 删除 \pkg{courier}，将 mono 字体替换为 TG Cursor，至此将正文字体全面替换为 OpenType.
+% \changes{v3.0.19}{2022/05/05}{删除 \pkg{courier}，将 mono 字体替换为 TG Cursor，至此将正文字体全面替换为 OpenType.}
+%    \begin{macrocode}
+
+\setmonofont{texgyrecursor}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+]
 
 %    \end{macrocode}
 % 添加数学字体开关
 %    \begin{macrocode}
 \ifhit@newtxmath
-\RequirePackage{newtxmath}
-\fi
 %    \end{macrocode}
-% \pkg{newtx} 的 Mono 字体虽然很好看，但在论文中不常见。学校虽未要求 Mono 字体，
-% 还是选择常见的 Courier 字体。由于比较新的实现 \TeX\ Gyre Cursor 会修
-% 改\cs{bfdefault}，导致中文加粗出问题，所以选用标准 \pkg{courier}。
+% 单独使用 \pkg{newtxmath} 宏包改变数学字体时，会使 \texttt{operators}，\cs{mathrm}，\cs{mathit}，\cs{mathbf} 命令使用 CM 字体，根据 \href{https://github.com/sjtug/SJTUThesis/blob/b164d0f5b3087ed86c1038b5a85014b47a92c6f2/texmf/tex/latex/sjtuthesis/fd/sjtu-math-font-termes.def#L52-L65}{SJTUThesis 的字体设置} 进行调整
+% \changes{v3.0.19}{2022/05/05}{对 \pkg{newtxmath} 宏包打补丁，修复 \texttt{operators}，\cs{mathrm}，\cs{mathit}，\cs{mathbf} 命令的字体问题。}
 %    \begin{macrocode}
-\RequirePackage{courier}
+\let\oldencodingdefault\encodingdefault
+\let\oldrmdefault\rmdefault
+\let\oldsfdefault\sfdefault
+\let\oldttdefault\ttdefault
+\usepackage[T1]{fontenc}
+\renewcommand{\rmdefault}{ntxtlf}
+\renewcommand{\sfdefault}{qhv}
+\renewcommand{\ttdefault}{ntxtt}
+\RequirePackage{newtxmath}
+\let\encodingdefault\oldencodingdefault
+\let\rmdefault\oldrmdefault
+\let\sfdefault\oldsfdefault
+\let\ttdefault\oldttdefault
+\fi
 %    \end{macrocode}
 % 图形支持宏包。
 %    \begin{macrocode}

--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -16,7 +16,7 @@
 %
 % \iffalse
 %<*driver>
-\ProvidesFile{hithesis.dtx}[2022/02/23 3.0.17 Harbin Institute of Technology Thesis Template]
+\ProvidesFile{hithesis.dtx}[2022/05/02 3.0.18 Harbin Institute of Technology Thesis Template]
 \documentclass{ltxdoc}
 \usepackage{dtx-style}
 
@@ -905,7 +905,7 @@
 %
 %
 % \subsection{捐助}
-% \changes{v1.0.1}{2017/08/27}{添加了捐助、矢量化本科论文模板的图片logo}
+% \changes{v1.0.01}{2017/08/27}{添加了捐助、矢量化本科论文模板的图片logo}
 % 各位刀客和大侠如用的嗨，要解囊相助，请支付宝赞助
 % 参照图\ref{zfb}~中提示操作（二维码被矢量化后之后去
 % 除了头像等冗余无用的部分～）。
@@ -2398,7 +2398,7 @@ FUNCTION {masterthesis} {                         % void Entry::masterthesis() {
                                                   %
 %    \end{macrocode}
 % 此处添加mastersthesis Entry
-% \changes{v3.0.1}{2020/06/06}{此处添加mastersthesis Entry}
+% \changes{v3.0.01}{2020/06/06}{此处添加mastersthesis Entry}
 %    \begin{macrocode}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
                                                   %
@@ -2994,7 +2994,27 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage{amsmath}
 \RequirePackage[amsmath,thmmarks,hyperref]{ntheorem}
 \RequirePackage{amssymb}
-\RequirePackage[defaultsups]{newtxtext}
+
+%    \end{macrocode}
+% 删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.
+% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.}
+%    \begin{macrocode}
+
+\setmainfont{texgyretermes}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+  Scale = 1.0]
+  
+\setsansfont{texgyreheros}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+  Scale = 0.9]
 
 \RequirePackage{courier}
 \RequirePackage{graphicx}
@@ -3010,9 +3030,8 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage{xeCJKfntef}
 %    \end{macrocode}
 % \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty} 
-% \changes{v3.0.7}{2020/09/18}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
+% \changes{v3.0.17}{2022/02/23}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
 %    \begin{macrocode}
-\IfFileExists{newtx.sty}{\PassOptionsToPackage{nofontspec}{newtxtext}}{}
 
 \RequirePackage{longtable}
 \RequirePackage{booktabs}
@@ -3406,7 +3425,28 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage{amsmath}
 \RequirePackage[amsmath,thmmarks,hyperref]{ntheorem}
 \RequirePackage{amssymb}
-\RequirePackage[defaultsups]{newtxtext}
+
+%    \end{macrocode}
+% 删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.
+% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.}
+%    \begin{macrocode}
+
+\setmainfont{texgyretermes}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+  Scale = 1.0]
+  
+\setsansfont{texgyreheros}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+  Scale = 0.9]
+
 \ifhit@newtxmath
 \RequirePackage{newtxmath}
 \fi
@@ -3432,9 +3472,8 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage{xeCJKfntef}
 %    \end{macrocode}
 % \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty} 
-% \changes{v3.0.7}{2020/09/18}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
+% \changes{v3.0.17}{2022/02/23}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
 %    \begin{macrocode}
-\IfFileExists{newtx.sty}{\PassOptionsToPackage{nofontspec}{newtxtext}}{}
 
 \RequirePackage{longtable}
 \RequirePackage{booktabs}
@@ -3492,9 +3531,9 @@ EXECUTE {end.bib}                                 %   end_bib();
 
 %    \end{macrocode}
 % 设置深圳校区开题报告的正文行距与毕业论文模板一致
-% \changes{v3.0.4}{2020/07/29}{设置深圳校区开题报告的正文行距与毕业论文模板一致}
+% \changes{v3.0.04}{2020/07/29}{设置深圳校区开题报告的正文行距与毕业论文模板一致}
 % 此处修改与正文行距保持一致
-% \changes{v3.0.5}{2020/09/13}{此处修改与正文行距保持一致}
+% \changes{v3.0.05}{2020/09/13}{此处修改与正文行距保持一致}
 %    \begin{macrocode}
 
 \renewcommand\normalsize{%
@@ -3529,7 +3568,7 @@ EXECUTE {end.bib}                                 %   end_bib();
 
 %    \end{macrocode}
 % 更改哈尔滨校区博士硕士开题节标题为小三号字体
-% \changes{v3.0.8}{2020/09/28}{更改哈尔滨校区博士硕士开题节标题为小三号字体}
+% \changes{v3.0.08}{2020/09/28}{更改哈尔滨校区博士硕士开题节标题为小三号字体}
 %    \begin{macrocode}
 
 %-- 设置字号 --%
@@ -3637,7 +3676,7 @@ EXECUTE {end.bib}                                 %   end_bib();
          \textbf{\hit@graduate@cmajortitle} & \underline{\makebox[6.1cm]{\textbf{\hit@csubject}}}\\
          \textbf{\hit@graduate@supervisor} & \underline{\makebox[6.1cm]{\textbf{\hit@csupervisor}}}\\
 %    \end{macrocode}
-% \changes{v3.0.3}{2020/07/03}{fix author name bug}
+% \changes{v3.0.03}{2020/07/03}{fix author name bug}
 %    \begin{macrocode}
          \textbf{\hit@graduate@studenttitle} & \underline{\makebox[6.1cm]{\textbf{\hit@cauthor}}}\\
          \textbf{\hit@graduate@studentid} & \underline{\makebox[6.1cm]{\textbf{\hit@cstudentid}}}\\
@@ -3861,11 +3900,11 @@ EXECUTE {end.bib}                                 %   end_bib();
 \DeclareBoolOption[false]{arialtitle}
 %    \end{macrocode}
 % 中文本科模板中章标题是否加粗，默认是
-% \changes{v3.0.1}{2020/06/06}{中文本科模板中章标题是否加粗，默认是}
+% \changes{v3.0.01}{2020/06/06}{中文本科模板中章标题是否加粗，默认是}
 %    \begin{macrocode}
 \DeclareBoolOption[true]{chapterbold}
 %    \end{macrocode}
-% \changes{v1.0.3}{2017/08/29}{默认开启raggedbottom}
+% \changes{v1.0.03}{2017/08/29}{默认开启raggedbottom}
 % \option{raggedbottom} 选项（默认开启）。如果不开启这个选项，会出现一页中尽量上
 % 下对齐，段的间距大。如果开启，尽量使段间距保持一致，页面底部出现空白。
 %    \begin{macrocode}
@@ -3914,12 +3953,12 @@ EXECUTE {end.bib}                                 %   end_bib();
 \DeclareBoolOption[false]{library}
 %    \end{macrocode}
 % 图题和标题最后一行是否居中对其（默认是，非规范要求）。
-% \changes{v1.0.6}{2017/10/25}{此处更改了选项的名称}
+% \changes{v1.0.06}{2017/10/25}{此处更改了选项的名称}
 %    \begin{macrocode}
 \DeclareBoolOption[false]{capcenterlast}
 %    \end{macrocode}
 % 子图图题和标题最后一行是否居中对其（默认是，非规范要求）。
-% \changes{v1.0.6}{2017/10/25}{此处添加子图最后一行图题是否居中选项}
+% \changes{v1.0.06}{2017/10/25}{此处添加子图最后一行图题是否居中选项}
 %    \begin{macrocode}
 \DeclareBoolOption[false]{subcapcenterlast}
 %    \end{macrocode}
@@ -3938,12 +3977,12 @@ EXECUTE {end.bib}                                 %   end_bib();
 \DeclareBoolOption[true]{bsheadrule}
 %    \end{macrocode}
 %    数学字体是否使用新罗马
-% \changes{v2.0.5}{2018/12/05}{添加数学字体开关}
+% \changes{v2.0.05}{2018/12/05}{添加数学字体开关}
 %    \begin{macrocode}
 \DeclareBoolOption[true]{newtxmath}
 %    \end{macrocode}
 %    此处应广大刀客要求添加一参考文献分割开关
-% \changes{v2.0.3}{2018/10/08}{添加参考文献分割开关}
+% \changes{v2.0.03}{2018/10/08}{添加参考文献分割开关}
 %    \begin{macrocode}
 \DeclareBoolOption[false]{splitbibitem}
 %    \end{macrocode}
@@ -3971,10 +4010,7 @@ EXECUTE {end.bib}                                 %   end_bib();
 \PassOptionsToPackage{no-math}{fontspec}
 %    \end{macrocode}
 % \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty} 
-% \changes{v3.0.7}{2020/09/18}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
-%    \begin{macrocode}
-\IfFileExists{newtx.sty}{\PassOptionsToPackage{nofontspec}{newtxtext}}{}
-%    \end{macrocode}
+% \changes{v3.0.17}{2022/02/23}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
 % 载入单双面打印设置，本、硕单面，博士双面。
 %    \begin{macrocode}
 \ifhit@bachelor
@@ -3987,7 +4023,7 @@ EXECUTE {end.bib}                                 %   end_bib();
 \PassOptionsToClass{twoside}{book}
 \fi
 %    \end{macrocode}
-% \changes{v1.0.2}{2017/08/27}{添加了思源字体说明}
+% \changes{v1.0.02}{2017/08/27}{添加了思源字体说明}
 % 设置字体。由于宋体没有粗体，且我工模板的标题要求使用粗宋体，于是面临CTeX的经典
 % 的伪粗体bug：“首次出现伪粗体字体之后的正常字体无法复制”。但如果使用自带宋体的
 % 思源字体，那么不必使用伪粗体。模板只给出了新windows字体的思源字体设置，且思源
@@ -4075,9 +4111,26 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage[amsmath,thmmarks,hyperref]{ntheorem}
 \RequirePackage{amssymb}
 %    \end{macrocode}
-% \pkg{newtx} 系列宏包设置 Times New Roman，Helvetica。
+% 删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.
+% \changes{v3.0.18}{2022/05/02}{删除 \pkg{newtxtext}, 由于最新一次更新 (\texttt{revision 62369}) 中与 \pkg{ctex} 宏包冲突, 且无法解决, 将正文字体替换为 TG Termes 与 TG Heros.}
 %    \begin{macrocode}
-\RequirePackage[defaultsups]{newtxtext}
+
+\setmainfont{texgyretermes}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+  Scale = 1.0]
+  
+\setsansfont{texgyreheros}[
+  UprightFont = *-regular ,
+  BoldFont = *-bold ,
+  ItalicFont = *-italic ,
+  BoldItalicFont = *-bolditalic ,
+  Extension = .otf ,
+  Scale = 0.9]
+
 %    \end{macrocode}
 % 添加数学字体开关
 %    \begin{macrocode}
@@ -4214,7 +4267,7 @@ EXECUTE {end.bib}                                 %   end_bib();
 \fi%
 %    \end{macrocode}
 %    载入显示行号的包。
-% \changes{v1.0.9}{2018/01/07}{添加debug包}
+% \changes{v1.0.09}{2018/01/07}{添加debug包}
 %    \begin{macrocode}
 \ifhit@debug%
 \RequirePackage{layout}
@@ -4227,7 +4280,7 @@ EXECUTE {end.bib}                                 %   end_bib();
 \RequirePackage{fancyhdr}
 %    \end{macrocode}
 % 其他包，表格、数学符号包
-% \changes{v1.0.6}{2017/10/25}{此处添加子图最后一行图题是否居中选项}
+% \changes{v1.0.06}{2017/10/25}{此处添加子图最后一行图题是否居中选项}
 %    \begin{macrocode}
 \RequirePackage{tabularx}
 \RequirePackage{varwidth}
@@ -4583,7 +4636,7 @@ delim_1 "\\hspace*{\\fill}"
         \ifhit@bachelor
 %    \end{macrocode}
 % 此处设置威海本科页眉与本部一样，窝工三个校区规范怎么这么乱？？？
-% \changes{v3.0.1}{2020/06/06}{此处设置威海本科页眉与本部一样，窝工三个校区规范怎么这么乱？？？}
+% \changes{v3.0.01}{2020/06/06}{此处设置威海本科页眉与本部一样，窝工三个校区规范怎么这么乱？？？}
 %    \begin{macrocode}
           \fancyhead[C]{\songti\xiaowu[0]\hit@cschoolname\hit@bachelor@cxuewei\hit@bachelor@cthesisname}%
         \else
@@ -4690,7 +4743,7 @@ delim_1 "\\hspace*{\\fill}"
 \postdisplaypenalty=0
 \renewcommand\theequation{\ifnum \c@chapter>\z@ \thechapter-\fi\@arabic\c@equation}
 %    \end{macrocode}
-% \changes{v2.0.3}{2018/10/08}{设置公式前后随意断页}
+% \changes{v2.0.03}{2018/10/08}{设置公式前后随意断页}
 % 公式距前后文的距离由 4 个参数控制，参见 \cs{normalsize} 的定义。
 % 同时为了让 \pkg{amsmath} 的 \cs{tag*} 命令得到正确的格式，我们必须修改这些代
 % 码。\cs{make@df@tag} 是定义 \cs{tag*} 和 \cs{tag} 内部命令的。
@@ -4739,7 +4792,7 @@ delim_1 "\\hspace*{\\fill}"
 \theoremsymbol{}
 %    \end{macrocode}
 % 此处去除了冒号，（如果需要在加上这个冒号？），反正规范中没有。
-% \changes{v2.0.2}{2018/06/28}{取出了定理冒号}
+% \changes{v2.0.02}{2018/06/28}{取出了定理冒号}
 %    \begin{macrocode}
 \theoremseparator{}
 \ifhit@english
@@ -4886,7 +4939,7 @@ delim_1 "\\hspace*{\\fill}"
 }
 %    \end{macrocode}
 % 此处删除了时间
-% \changes{v3.0.6}{2020/09/13}{此处删除了时间}
+% \changes{v3.0.06}{2020/09/13}{此处删除了时间}
 %    \begin{macrocode}
 \newcommand{\hit@harbin@schoolbottommark}{
    \begin{center}
@@ -4922,8 +4975,8 @@ delim_1 "\\hspace*{\\fill}"
 % \label{sec:float}
 % 设置浮动对象和文字之间的距离，由于规范中没有明确规定，根据经验，设置成正文汉字
 % 高度。
-% \changes{v1.0.9}{2018/01/07}{修正float垂直间距bug}
-% \changes{v2.0.9}{2019/06/24}{修正float垂直间距bug}
+% \changes{v1.0.09}{2018/01/07}{修正float垂直间距bug}
+% \changes{v2.0.09}{2019/06/24}{修正float垂直间距bug}
 %    \begin{macrocode}
 %<*bookcls>
 \ifhit@postdoc
@@ -4942,11 +4995,11 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 %    此处设置float在p选项时间隔，此处不设置\cs{@fptop}和\cs{@fpbot}以确保居中。
 % \changes{v1.0.12}{2018/04/03}{修正float为p状态时默认不居中bug}
-% \changes{v2.0.4}{2018/12/04}{删除\cs{@fpsep}设置，似乎没有什么用}
-% \changes{v2.0.4}{2018/12/04}{更新\cs{intextsep}\cs{textfloatsep}\cs{floatsep}间距为正文行间距}
+% \changes{v2.0.04}{2018/12/04}{删除\cs{@fpsep}设置，似乎没有什么用}
+% \changes{v2.0.04}{2018/12/04}{更新\cs{intextsep}\cs{textfloatsep}\cs{floatsep}间距为正文行间距}
 % 下面这组命令使浮动对象的缺省值稍微宽松一点，从而防止幅度对象占据过多的文本页面，
 % 也可以防止在很大空白的浮动页上放置很小的图形。
-% \changes{v1.0.8}{2017/11/5}{修改附录中图、表、公式数字编码}
+% \changes{v1.0.08}{2017/11/5}{修改附录中图、表、公式数字编码}
 %    \begin{macrocode}
 \g@addto@macro\appendix{\renewcommand*{\thefigure}{\thechapter-\arabic{figure}}}
 \g@addto@macro\appendix{\renewcommand*{\thetable}{\thechapter-\arabic{table}}}
@@ -4957,9 +5010,9 @@ delim_1 "\\hspace*{\\fill}"
 \renewcommand{\floatpagefraction}{0.60}
 %    \end{macrocode}
 % 由于我工的双标题，导致标题之下多出一空白字符的距离，去除。
-% \changes{v2.0.4}{2018/12/04}{更新图段后空白距离}
-% \changes{v2.0.4}{2018/12/04}{删除表段后空白距离}
-% \changes{v2.0.5}{2018/12/05}{删除图段后空白距离}
+% \changes{v2.0.04}{2018/12/04}{更新图段后空白距离}
+% \changes{v2.0.04}{2018/12/04}{删除表段后空白距离}
+% \changes{v2.0.05}{2018/12/05}{删除图段后空白距离}
 %    \begin{macro}{\@makecaption}
 %    根据我工规范，本科和硕博的图题序号之后的空格不一样。
 %    \begin{hitrgu}[\PGR][2.13.1]
@@ -4972,8 +5025,8 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{hitrgu}
 %    我工规范中没有明确规定是否标题是否居中对齐，这里给出一个居中选项自行调整。
 % 注意，我工只规定：“居中书写”。此处不额外添加悬挂处理。
-% \changes{v1.0.6}{2017/10/25}{此处更改了选项的名称}
-% \changes{v1.0.7}{2017/11/4}{优化了最后一行居中算法，使其两边对齐、单词内部断行}
+% \changes{v1.0.06}{2017/10/25}{此处更改了选项的名称}
+% \changes{v1.0.07}{2017/11/4}{优化了最后一行居中算法，使其两边对齐、单词内部断行}
 %    \begin{macrocode}
 \long\def\@makecaption#1#2{%
   \vskip\abovecaptionskip
@@ -5056,7 +5109,7 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 %    \end{macro}
 %    图表名称及格式。
-%    \changes{v1.0.8}{2017/11/5}{删除冗余公式符号定义}
+%    \changes{v1.0.08}{2017/11/5}{删除冗余公式符号定义}
 %    \begin{macrocode}
 \renewcommand{\thesubtable}{(\alph{subtable})}
 \renewcommand{\thefigure}{\arabic{chapter}-\arabic{figure}}%使图编号为 7-1 的格式 %\protect{~}
@@ -5074,7 +5127,7 @@ delim_1 "\\hspace*{\\fill}"
 \newcommand{\citeup}[1]{\textsuperscript{\cite{#1}}}
 %    \end{macrocode}
 % 此处删除hang caption的设置
-% \changes{v1.0.6}{2017/10/25}{删除caption hang 的默认设置，因为不在规范要求中}
+% \changes{v1.0.06}{2017/10/25}{删除caption hang 的默认设置，因为不在规范要求中}
 %    \begin{macrocode}
 \captionnamefont{\wuhao}
 \captiontitlefont{\wuhao}
@@ -5099,7 +5152,7 @@ delim_1 "\\hspace*{\\fill}"
 {\end{list}}
 %    \end{macrocode}
 % 设置定理定义格式
-% \changes{v2.0.1}{2018/6/28}{去除定理注释括号}
+% \changes{v2.0.01}{2018/6/28}{去除定理注释括号}
 %    \begin{macrocode}
 \renewtheoremstyle{plain}
 {\item[\hskip\labelsep \theorem@headerfont ##1\ ##2\theorem@separator]}
@@ -5365,7 +5418,7 @@ delim_1 "\\hspace*{\\fill}"
       aftername=\enspace,
 %    \end{macrocode}
 % 添加本科生章标题加粗选项
-% \changes{v3.0.1}{2020/06/06}{添加本科生章标题加粗选项}
+% \changes{v3.0.01}{2020/06/06}{添加本科生章标题加粗选项}
 %    \begin{macrocode}
       format={\centering\hit@title@font\xiaoer[1.57481]\ifhit@chapterbold\ifhit@bachelor\bfseries\fi\fi},%\center 会影响之后全局
       nameformat=\relax,
@@ -5497,7 +5550,7 @@ delim_1 "\\hspace*{\\fill}"
     \IfValueT{#4}{%
 %    \end{macrocode}
 %    此处需删除章节的空白
-% \changes{v1.0.5}{2017/09/20}{添加\cs{ignorespaces}选项，矫正英文目录多出一个空白而无法对其的bug}
+% \changes{v1.0.05}{2017/09/20}{添加\cs{ignorespaces}选项，矫正英文目录多出一个空白而无法对其的bug}
 % 此处添加保护选项
 % \changes{v1.0.13}{2018/4/5}{添加\cs{texorpdfstring}命令去除书签中带有格式时的警告}
 %    \begin{macrocode}
@@ -5524,7 +5577,7 @@ delim_1 "\\hspace*{\\fill}"
     \IfValueT{#4}{%
 %    \end{macrocode}
 %    此处需删除章节的空白
-% \changes{v1.0.5}{2017/09/18}{添加\cs{ignorespaces}选项，矫正英文目录多出一个空白而无法对其的bug}
+% \changes{v1.0.05}{2017/09/18}{添加\cs{ignorespaces}选项，矫正英文目录多出一个空白而无法对其的bug}
 %    \begin{macrocode}
     \addcontentsline{toe}{section}{\protect\numberline{\csname thesection\endcsname}\ignorespaces #4}
     }
@@ -5549,7 +5602,7 @@ delim_1 "\\hspace*{\\fill}"
     \IfValueT{#4}{%
 %    \end{macrocode}
 %    此处需删除章节的空白
-% \changes{v1.0.5}{2017/09/18}{添加\cs{ignorespaces}选项，矫正英文目录多出一个空白而无法对其的bug}
+% \changes{v1.0.05}{2017/09/18}{添加\cs{ignorespaces}选项，矫正英文目录多出一个空白而无法对其的bug}
 %    \begin{macrocode}
     \addcontentsline{toe}{subsection}{\protect\numberline{\csname thesubsection\endcsname}\ignorespaces #4}
     }
@@ -5574,7 +5627,7 @@ delim_1 "\\hspace*{\\fill}"
     \IfValueT{#4}{%
 %    \end{macrocode}
 %    此处需删除章节的空白
-% \changes{v1.0.5}{2017/09/18}{添加\cs{ignorespaces}选项，矫正英文目录多出一个空白而无法对其的bug}
+% \changes{v1.0.05}{2017/09/18}{添加\cs{ignorespaces}选项，矫正英文目录多出一个空白而无法对其的bug}
 %    \begin{macrocode}
     \addcontentsline{toe}{subsubsection}{\protect\numberline{\csname thesubsubsection\endcsname}\ignorespaces #4}
     }
@@ -6142,7 +6195,7 @@ delim_1 "\\hspace*{\\fill}"
               \hit@bachelor@caffiltitlesz%
 %    \end{macrocode}
 % 此处删除威海本科封皮中威海校区字样
-% \changes{v3.0.1}{2020/06/06}{此处删除威海本科封皮中威海校区字样}
+% \changes{v3.0.01}{2020/06/06}{此处删除威海本科封皮中威海校区字样}
 %    \begin{macrocode}
             % \else%
             %   \ifhit@weihai%
@@ -6189,7 +6242,7 @@ delim_1 "\\hspace*{\\fill}"
   % \centering{\includegraphics[width=6.2cm]{hitlogo}~~\raisebox{0.2em}{\kaishu\yihao\hit@weihaicampus}}
 %    \end{macrocode}
 % 删除威海字样
-% \changes{v3.0.1}{2020/06/06}{删除威海字样}
+% \changes{v3.0.01}{2020/06/06}{删除威海字样}
 %    \begin{macrocode}
   \centering{\includegraphics[width=6.2cm]{hitlogo}}
   \fi%
@@ -6205,7 +6258,7 @@ delim_1 "\\hspace*{\\fill}"
 	\setlength{\hit@title@width}{5.5em}
 	\begin{tabular}{l@{\ \  }c}
 %    \end{macrocode}
-% 　 \changes{v3.0.1}{2020/06/06}{此处添加自动设置字号}
+% 　 \changes{v3.0.01}{2020/06/06}{此处添加自动设置字号}
 %    \begin{macrocode}
 	  {\xiaoer  \hit@put@title{\hit@bachelor@cthesistitle}} & \underline{\makebox[6.1cm]{%
     \settowidth{\hit@ctitleonelength}{\xiaoer \hit@ctitleone}%
@@ -6308,7 +6361,7 @@ delim_1 "\\hspace*{\\fill}"
   \begin{center}
     %    \end{macrocode}
 % 深圳硕士英文封面第一行文字不同，修改。
-% \changes{v3.0.9}{2020/10/17}{深圳硕士英文封面第一行文字不同，修改。}
+% \changes{v3.0.09}{2020/10/17}{深圳硕士英文封面第一行文字不同，修改。}
 %    \begin{macrocode}
   \parbox[t][1.6cm][t]{\textwidth}{\begin{center} \end{center} }
     \parbox[t][3.5cm][t]{\textwidth}{\xiaoer[1]
@@ -6515,7 +6568,7 @@ delim_1 "\\hspace*{\\fill}"
 %    \end{macrocode}
 % 此处临时更改一下对齐方式。\CTeX\ 似乎无法应对双语目录。
 % todo:
-% \changes{v1.0.4}{2017/09/17}{将leftskip设置参数至于外侧，以便后续添加可以适应标题长度的\cs{contentsline}方法}
+% \changes{v1.0.04}{2017/09/17}{将leftskip设置参数至于外侧，以便后续添加可以适应标题长度的\cs{contentsline}方法}
 %    \begin{macrocode}
 \setlength\@tempdima{4em}%
 \patchcmd{\@dottedtocline}{#4}{\csname hit@toc@font\endcsname #4}{}{}
@@ -6533,9 +6586,9 @@ delim_1 "\\hspace*{\\fill}"
       % numberline is called here, and it uses \@tempdima
 %    \end{macrocode}
 % 修改本科生论文目录格式
-% \changes{v2.0.8}{2017/06/15}{修改本科生论文目录格式（感谢QQ:嬴政　同学）}
+% \changes{v2.0.08}{2017/06/15}{修改本科生论文目录格式（感谢QQ:嬴政　同学）}
 % 本科目录添加加粗
-% \changes{v3.0.1}{2020/06/06}{本科目录添加加粗}
+% \changes{v3.0.01}{2020/06/06}{本科目录添加加粗}
 %    \begin{macrocode}
       {\ifhit@bachelor\rmfamily\else\csname
         hit@toc@font\endcsname\fi\heiti\ifhit@postdoc\bfseries\fi\ifhit@chapterbold\ifhit@bachelor\bfseries\fi\fi\ifhit@english\bfseries\fi #1}
@@ -6569,7 +6622,7 @@ delim_1 "\\hspace*{\\fill}"
 \newcommand\tableofengcontents{
 %    \end{macrocode}
 %    此处添加英文目录的章标题格式，默认细点
-% \changes{v1.0.5}{2017/09/18}{矫正英文目录缩进与中文目录一致的bug}
+% \changes{v1.0.05}{2017/09/18}{矫正英文目录缩进与中文目录一致的bug}
 %    \begin{macrocode}
   \def\l@chapter{\@dottedtocline{0}{0em}{5em}}%控制英文目录： 细点\@dottedtocline  粗点\@dottedtoclinebold
   \@restonecolfalse
@@ -6579,9 +6632,9 @@ delim_1 "\\hspace*{\\fill}"
   \engcontentsname}{\engcontentsname}}
 %    \end{macrocode}
 % 此处临时更改一下对齐方式。\CTeX\ 似乎无法应对双语目录。
-% \changes{v1.0.4}{2017/09/17}{修正英文目录中换行时无法对齐的bug}
+% \changes{v1.0.04}{2017/09/17}{修正英文目录中换行时无法对齐的bug}
 % 删除增加\cs{hangindent}的方法，其原因是\cs{numberline}多出一个空格
-% \changes{v1.0.5}{2017/09/18}{彻底修正英文目录中换行时无法对齐的bug}
+% \changes{v1.0.05}{2017/09/18}{彻底修正英文目录中换行时无法对齐的bug}
 %    \begin{macrocode}
   \@starttoc{toe}%
   \if@restonecol\twocolumn\fi}
@@ -6741,7 +6794,7 @@ delim_1 "\\hspace*{\\fill}"
 %    \begin{macrocode}
 % \newcommand\bibstyle@authoryear{\bibpunct{(}{)}{;}{a}{,}{,}}
 %    \end{macrocode}
-% \changes{v2.0.6}{2018/12/5}{在\cs{inlinecite}内添加空格}
+% \changes{v2.0.06}{2018/12/5}{在\cs{inlinecite}内添加空格}
 %    \begin{macrocode}
 % \newcommand\bibstyle@inline{\bibpunct{[}{]}{,}{n}{,}{\hit@inline@sep}}
 \citestyle{numerical}
@@ -6764,11 +6817,11 @@ delim_1 "\\hspace*{\\fill}"
   \renewcommand\theenumiv{\@arabic\c@enumiv}}%
   \sloppy\frenchspacing
 %    \end{macrocode}
-% \changes{v2.0.7}{2019/03/02}{添加flushbottom到thebibliography环境中}
+% \changes{v2.0.07}{2019/03/02}{添加flushbottom到thebibliography环境中}
 %    \begin{macrocode}
   \flushbottom
 %    \end{macrocode}
-% \changes{v2.0.3}{2018/10/08}{添加参考文献分割开关}
+% \changes{v2.0.03}{2018/10/08}{添加参考文献分割开关}
 %    \begin{macrocode}
   \ifhit@splitbibitem
   \clubpenalty0
@@ -7157,7 +7210,7 @@ breaklines=true
 \RequirePackage{hypdoc}
 %    \end{macrocode}
 % 默认字体为fandol
-% \changes{v3.0.2}{2020/06/11}{默认字体为fandol}
+% \changes{v3.0.02}{2020/06/11}{默认字体为fandol}
 %    \begin{macrocode}
 \RequirePackage[UTF8,scheme=chinese,fontset=fandol]{ctex}
 \RequirePackage{newpxtext}
@@ -7276,7 +7329,7 @@ breaklines=true
 %<bookcfg|dtx-style>{《\hit 本科生毕业论文撰写规范》}}
 %<bookcfg>\def\hit@inline@sep{，}
 %    \end{macrocode}
-% \changes{v2.0.6}{2018/12/5}{在\cs{inlinecite}内添加空格}
+% \changes{v2.0.06}{2018/12/5}{在\cs{inlinecite}内添加空格}
 %    \begin{macrocode}
 %<*dtx-style>
   \NewDocumentEnvironment{hitrgu}{o o}


### PR DESCRIPTION
在 v1.71 的 `newtx` 宏包中, 如果想与 ctex 宏包一起使用, 需要使用 `nofontspec` 选项, 但是该版本 (revision 62369) 的该选项在 xelatex 编译下显示异常, mwe 如下

```latex
\documentclass{article}
\usepackage[nofontspec]{newtxtext}
\begin{document}
  text, \textbf{text}, \textit{text}, \textit{\textbf{text}}
\end{document}
```

![image](https://user-images.githubusercontent.com/38098591/166215171-9fa8561f-b0f0-4dfc-a577-341a8b51bf49.png)


而使用 pdflatex 编译正常:

![image](https://user-images.githubusercontent.com/38098591/166215212-2d90d5ff-d489-4f95-a6c7-4030e81fec3c.png)


而本模板无法使用 pdflatex 编译, 故该问题无法解决, 先替换为 `TeX Gyre Termes` 与 `TeX Gyre Heros`. 