### PR TITLE
重定义三线表线宽、修正长表格格式、修正表格标签

### DIFF
--- a/examples/hitbook/chinese/body/introduction.tex
+++ b/examples/hitbook/chinese/body/introduction.tex
@@ -344,13 +344,13 @@ R是一种极具有代表性的典型的作图工具，应用广泛。
 \bicaption[table1]{}{符合研究生院绘图规范的表格}{Table$\!$}{Table in agreement of the standard from graduate school}
 \vspace{0.5em}\centering\wuhao
 \begin{tabular}{ccccc}
-\toprule[1.5pt]
+\toprule
 $D$(in) & $P_u$(lbs) & $u_u$(in) & $\beta$ & $G_f$(psi.in)\\
-\midrule[1pt]
+\midrule
  5 & 269.8 & 0.000674 & 1.79 & 0.04089\\
 10 & 421.0 & 0.001035 & 3.59 & 0.04089\\
 20 & 640.2 & 0.001565 & 7.18 & 0.04089\\
-\bottomrule[1.5pt]
+\bottomrule
 \end{tabular}
 \end{table}
 全表如用同一单位，则将单位符号移至表头右上角，加圆括号。表中数据应准确无误，书写
@@ -374,14 +374,14 @@ $D$(in) & $P_u$(lbs) & $u_u$(in) & $\beta$ & $G_f$(psi.in)\\
 \wuhao[1.667]\begin{longtable}{ccc}%
 \longbionenumcaption{}{{\wuhao 中国省级行政单位一览}\label{table2}}{Table$\!$}{}{{\wuhao Overview of the provincial administrative unit of China}}{-0.5em}{3.15bp}\\
 %\caption{\wuhao 中国省级行政单位一览}\label{table2}\\
-\toprule[1.5pt] 名称 & 简称 & 省会或首府  \\ \midrule[1pt]
+\toprule 名称 & 简称 & 省会或首府\\ \midrule
 \endfirsthead
 \multicolumn{3}{r}{表~\thetable（续表）}\vspace{0.5em}\\
-\toprule[1.5pt] 名称 & 简称 & 省会或首府  \\ \midrule[1pt]
+\toprule 名称 & 简称 & 省会或首府\\ \midrule
 \endhead
 \midrule[0.5pt]
 \endfoot
-\bottomrule[1.5pt]
+\bottomrule
 \endlastfoot
 北京市 & 京 & 北京\\
 天津市 & 津 & 天津\\
@@ -435,11 +435,13 @@ some cells of tables are too long]
   \centering
 \bicaption[table3]{}{最小的三个正整数的英文表示法}{Table$\!$}{The English construction of the smallest three positive integral numbers}\vspace{0.5em}\wuhao
 \begin{tabularx}{0.7\textwidth}{llX}
-\toprule[1.5pt]
-Value & Name & Alternate names, and names for sets of the given size\\\midrule[1pt]
+\toprule
+Value & Name & Alternate names, and names for sets of the given size\\
+\midrule
 1 & One & ace, single, singleton, unary, unit, unity\\
 2 & Two & binary, brace, couple, couplet, distich, deuce, double, doubleton, duad, duality, duet, duo, dyad, pair, snake eyes, span, twain, twosome, yoke\\
-3 & Three & deuce-ace, leash, set, tercet, ternary, ternion, terzetto, threesome, tierce, trey, triad, trine, trinity, trio, triplet, troika, hat-trick\\\bottomrule[1.5pt]
+3 & Three & deuce-ace, leash, set, tercet, ternary, ternion, terzetto, threesome, tierce, trey, triad, trine, trinity, trio, triplet, troika, hat-trick\\
+\bottomrule
 \end{tabularx}
 \end{table}
 tabularx环境共有两个必选参数：第1个参数用来确定表格的总宽度，第2个参数用来确定每
@@ -484,13 +486,13 @@ need to be annotated]
 \bicaption[table4]{}{不在规范中规定的横版表格}{Table$\!$}{A table style which is not stated in the regulation}
 \vspace{0.5em}\centering\wuhao
 \begin{tabular}{ccccc}
-\toprule[1.5pt]
+\toprule
 $D$(in) & $P_u$(lbs) & $u_u$(in) & $\beta$ & $G_f$(psi.in)\\
-\midrule[1pt]
+\midrule
  5 & 269.8 & 0.000674 & 1.79 & 0.04089\\
 10 & 421.0 & 0.001035 & 3.59 & 0.04089\\
 20 & 640.2 & 0.001565 & 7.18 & 0.04089\\
-\bottomrule[1.5pt]
+\bottomrule
 \end{tabular}
 \end{minipage}
 \end{sideways}

--- a/examples/hitbook/chinese/body/introduction.tex
+++ b/examples/hitbook/chinese/body/introduction.tex
@@ -372,17 +372,17 @@ $D$(in) & $P_u$(lbs) & $u_u$(in) & $\beta$ & $G_f$(psi.in)\\
 \vspace{-1.5bp}
 \ltfontsize{\wuhao[1.667]}
 \wuhao[1.667]\begin{longtable}{ccc}%
-\longbionenumcaption{}{{\wuhao 中国省级行政单位一览
-}\label{table3}}{Table$\!$}{}{{\wuhao Overview of the provincial administrative
-unit of China}}{-0.5em}{3.15bp}\\
-%\caption{\wuhao 中国省级行政单位一览}\\
+\longbionenumcaption{}{{\wuhao 中国省级行政单位一览}\label{table2}}{Table$\!$}{}{{\wuhao Overview of the provincial administrative unit of China}}{-0.5em}{3.15bp}\\
+%\caption{\wuhao 中国省级行政单位一览}\label{table2}\\
 \toprule[1.5pt] 名称 & 简称 & 省会或首府  \\ \midrule[1pt]
 \endfirsthead
 \multicolumn{3}{r}{表~\thetable（续表）}\vspace{0.5em}\\
 \toprule[1.5pt] 名称 & 简称 & 省会或首府  \\ \midrule[1pt]
 \endhead
-\bottomrule[1.5pt]
+\midrule[0.5pt]
 \endfoot
+\bottomrule[1.5pt]
+\endlastfoot
 北京市 & 京 & 北京\\
 天津市 & 津 & 天津\\
 河北省 & 冀 & 石家庄市\\
@@ -433,7 +433,7 @@ some cells of tables are too long]
 首先给出这种情况下的一个例子如表~\ref{table3}~所示。
 \begin{table}[htbp]
   \centering
-\bicaption[table4]{}{最小的三个正整数的英文表示法}{Table$\!$}{The English construction of the smallest three positive integral numbers}\vspace{0.5em}\wuhao
+\bicaption[table3]{}{最小的三个正整数的英文表示法}{Table$\!$}{The English construction of the smallest three positive integral numbers}\vspace{0.5em}\wuhao
 \begin{tabularx}{0.7\textwidth}{llX}
 \toprule[1.5pt]
 Value & Name & Alternate names, and names for sets of the given size\\\midrule[1pt]
@@ -481,7 +481,7 @@ need to be annotated]
 \centering
 \begin{sideways}
 \begin{minipage}{\textheight}
-\bicaption[table2]{}{不在规范中规定的横版表格}{Table$\!$}{A table style which is not stated in the regulation}
+\bicaption[table4]{}{不在规范中规定的横版表格}{Table$\!$}{A table style which is not stated in the regulation}
 \vspace{0.5em}\centering\wuhao
 \begin{tabular}{ccccc}
 \toprule[1.5pt]

--- a/examples/hitbook/chinese/front/denotation.tex
+++ b/examples/hitbook/chinese/front/denotation.tex
@@ -3,11 +3,11 @@
 \caption{国际单位制中具有专门名称的导出单位}
 \vspace{0.5em}\centering\wuhao
 \begin{tabular}{ccccc}
-\toprule[1.5pt]
+\toprule
 量的名称&单位名称&单位符号&其它表示实例\\
-\midrule[1pt]
+\midrule
 频率&赫[兹]&Hz&s-1\\
-\bottomrule[1.5pt]
+\bottomrule
 \end{tabular}
 \end{table}
 \end{denotation}

--- a/examples/hitbook/english/front/denotation.tex
+++ b/examples/hitbook/english/front/denotation.tex
@@ -3,11 +3,11 @@
 \caption{国际单位制中具有专门名称的导出单位}
 \vspace{0.5em}\centering\wuhao
 \begin{tabular}{ccccc}
-\toprule[1.5pt]
+\toprule
 量的名称&单位名称&单位符号&其它表示实例\\
-\midrule[1pt]
+\midrule
 频率&赫[兹]&Hz&s-1\\
-\bottomrule[1.5pt]
+\bottomrule
 \end{tabular}
 \end{table}
 \end{denotation}

--- a/hithesis.dtx
+++ b/hithesis.dtx
@@ -16,7 +16,7 @@
 %
 % \iffalse
 %<*driver>
-\ProvidesFile{hithesis.dtx}[2022/05/05 3.0.19 Harbin Institute of Technology Thesis Template]
+\ProvidesFile{hithesis.dtx}[2022/05/06 3.0.20 Harbin Institute of Technology Thesis Template]
 \documentclass{ltxdoc}
 \usepackage{dtx-style}
 
@@ -547,11 +547,11 @@
 % \caption{国际单位制中具有专门名称的导出单位}
 % \vspace{0.5em}\centering\wuhao
 % \begin{tabular}{ccccc}
-% \toprule[1.5pt]
+% \toprule
 % 量的名称&单位名称&单位符号&其它表示实例\\
-% \midrule[1pt]
+% \midrule
 % 频率&赫[兹]&Hz&s-1\\
-% \bottomrule[1.5pt]
+% \bottomrule
 % \end{tabular}
 % \end{table}
 % \end{denotation}
@@ -632,13 +632,13 @@
 % \bicaption[table1]{}{符合研究生院绘图规范的表格}{Table$\!$}{Table in agreement of the standard from graduate school}
 % \vspace{0.5em}\centering\wuhao
 % \begin{tabular}{ccccc}
-% \toprule[1.5pt]
+% \toprule
 % $D$(in) & $P_u$(lbs) & $u_u$(in) & $\beta$ & $G_f$(psi.in)\\
-% \midrule[1pt]
+% \midrule
 %  5 & 269.8 & 0.000674 & 1.79 & 0.04089\\
 % 10 & 421.0 & 0.001035 & 3.59 & 0.04089\\
 % 20 & 640.2 & 0.001565 & 7.18 & 0.04089\\
-% \bottomrule[1.5pt]
+% \bottomrule
 % \end{tabular}
 % \end{table}
 % \end{latex}
@@ -652,12 +652,12 @@
 % unit of China}}{-0.5em}{3.15bp}\\ %注意后两个参数分别是中英标题间距、标题和表格的间距。
 % %\caption{\wuhao 中国省级行政单位一览}\\[1em] %注意此处是标题和表格间距，这行
 % %是单语标题
-% \toprule[1.5pt] 名称 & 简称 & 省会或首府  \\ \midrule[1pt]
+% \toprule 名称 & 简称 & 省会或首府  \\ \midrule
 % \endfirsthead
 % \multicolumn{3}{r}{表~\thetable（续表）}\vspace{0.5em}\\
-% \toprule[1.5pt] 名称 & 简称 & 省会或首府  \\ \midrule[1pt]
+% \toprule 名称 & 简称 & 省会或首府  \\ \midrule
 % \endhead
-% \bottomrule[1.5pt]
+% \bottomrule
 % \endfoot
 % 北京市 & 京 & 北京\\
 % 天津市 & 津 & 天津\\
@@ -3008,7 +3008,7 @@ EXECUTE {end.bib}                                 %   end_bib();
   BoldItalicFont = *-BoldItalic ,
   Extension = .otf ,
   ]
-  
+
 \setsansfont{texgyreheros}[
   UprightFont = *-regular ,
   BoldFont = *-bold ,
@@ -3040,12 +3040,19 @@ EXECUTE {end.bib}                                 %   end_bib();
 %    \begin{macrocode}
 \RequirePackage{xeCJKfntef}
 %    \end{macrocode}
-% \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty} 
+% \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}
 % \changes{v3.0.17}{2022/02/23}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
 %    \begin{macrocode}
 
 \RequirePackage{longtable}
 \RequirePackage{booktabs}
+%    \end{macrocode}
+% 重定义 \pkg{booktabs} 宏包的默认线宽，绘制三线表时不再需要显式设置，以实现更好的内容与格式分离
+% \changes{v3.0.20}{2022/5/6}{重定义 \pkg{booktabs} 宏包的默认线宽，绘制三线表时不再需要显式设置，以实现更好的内容与格式分离}
+%    \begin{macrocode}
+\heavyrulewidth=1.5pt
+\lightrulewidth=1pt
+\cmidrulewidth=0.5pt
 \RequirePackage[sort&compress,numbers]{natbib}
 \RequirePackage{hyperref}
 \hypersetup{%
@@ -3450,7 +3457,7 @@ EXECUTE {end.bib}                                 %   end_bib();
   BoldItalicFont = *-BoldItalic ,
   Extension = .otf ,
   ]
-  
+
 \setsansfont{texgyreheros}[
   UprightFont = *-regular ,
   BoldFont = *-bold ,
@@ -3518,12 +3525,19 @@ EXECUTE {end.bib}                                 %   end_bib();
 %    \begin{macrocode}
 \RequirePackage{xeCJKfntef}
 %    \end{macrocode}
-% \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty} 
+% \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}
 % \changes{v3.0.17}{2022/02/23}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
 %    \begin{macrocode}
 
 \RequirePackage{longtable}
 \RequirePackage{booktabs}
+%    \end{macrocode}
+% 重定义 \pkg{booktabs} 宏包的默认线宽，绘制三线表时不再需要显式设置，以实现更好的内容与格式分离
+% \changes{v3.0.20}{2022/5/6}{重定义 \pkg{booktabs} 宏包的默认线宽，绘制三线表时不再需要显式设置，以实现更好的内容与格式分离}
+%    \begin{macrocode}
+\heavyrulewidth=1.5pt
+\lightrulewidth=1pt
+\cmidrulewidth=0.5pt
 \RequirePackage[sort&compress,numbers]{natbib}
 \RequirePackage{hyperref}
 \hypersetup{%
@@ -4056,7 +4070,7 @@ EXECUTE {end.bib}                                 %   end_bib();
 %    \begin{macrocode}
 \PassOptionsToPackage{no-math}{fontspec}
 %    \end{macrocode}
-% \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty} 
+% \pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}
 % \changes{v3.0.17}{2022/02/23}{\pkg{newtx} 更新至 v1.7 版本后与 \pkg{ctex} 宏包冲突, 需要手动引入 \option{nofontspec} 选项. 判断方法为是否存在 v1.7 更新后的新宏包 \pkg{newtx.sty}}
 % 载入单双面打印设置，本、硕单面，博士双面。
 %    \begin{macrocode}
@@ -4170,7 +4184,7 @@ EXECUTE {end.bib}                                 %   end_bib();
   BoldItalicFont = *-BoldItalic ,
   Extension = .otf ,
   ]
-  
+
 \setsansfont{texgyreheros}[
   UprightFont = *-regular ,
   BoldFont = *-bold ,
@@ -4257,6 +4271,13 @@ EXECUTE {end.bib}                                 %   end_bib();
 % 使用三线表：\cs{toprule}，\cs{midrule}，\cs{bottomrule}。
 %    \begin{macrocode}
 \RequirePackage{booktabs}
+%    \end{macrocode}
+% 重定义 \pkg{booktabs} 宏包的默认线宽，绘制三线表时不再需要显式设置，以实现更好的内容与格式分离
+% \changes{v3.0.20}{2022/5/6}{重定义 \pkg{booktabs} 宏包的默认线宽，绘制三线表时不再需要显式设置，以实现更好的内容与格式分离}
+%    \begin{macrocode}
+\heavyrulewidth=1.5pt
+\lightrulewidth=1pt
+\cmidrulewidth=0.5pt
 %    \end{macrocode}
 % 参考文献引用宏包。
 % \changes{v3.0.15}{2020/5/21}{删去natbib package}
@@ -7290,6 +7311,13 @@ breaklines=true
   left=4cm, right=2cm,
   headsep=3mm]{geometry}
 \RequirePackage{array,longtable,booktabs}
+%    \end{macrocode}
+% 重定义 \pkg{booktabs} 宏包的默认线宽，绘制三线表时不再需要显式设置，以实现更好的内容与格式分离
+% \changes{v3.0.20}{2022/5/6}{重定义 \pkg{booktabs} 宏包的默认线宽，绘制三线表时不再需要显式设置，以实现更好的内容与格式分离}
+%    \begin{macrocode}
+\heavyrulewidth=1.5pt
+\lightrulewidth=1pt
+\cmidrulewidth=0.5pt
 \RequirePackage{listings}
 \RequirePackage{fancyhdr}
 \RequirePackage{xcolor}
@@ -9893,4 +9921,3 @@ showpage
 %  TeX-master: t
 %  End:
 % \fi
-


### PR DESCRIPTION
几个关于表格的更新：

1. 重定义了 `booktabs` 宏包的线宽，使其符合《书写范例》，这样在排版表格的时候就不用手动指定线宽了，实现更好的内容与格式分离
2. 修正了示例文档中的长表格格式，使其符合《书写范例》：未完成的表格尾部应该采用约 0.5 磅的细线，而非 1.5 磅的粗线（顺便吐槽一下，Word 版《书写范例》上这条细线居然是手画了一条直线，甚至都不是平的）
3. 修正了示例文档中表格标签的问题